### PR TITLE
Fixed remote path adapting to the Dropbox directory restructure

### DIFF
--- a/cs_api/setup.py
+++ b/cs_api/setup.py
@@ -1,6 +1,7 @@
 """
 Install script for the cs_api package.
 """
+
 from setuptools import setup, find_packages
 
 setup(

--- a/dropbox_rclone/dropbox_rclone/contants.py
+++ b/dropbox_rclone/dropbox_rclone/contants.py
@@ -1,2 +1,2 @@
 # Dropbox directory
-CYBERSHAKE_DIRECTORY = "dropbox:Cybershake"
+CYBERSHAKE_DIRECTORY = "dropbox:/Quake\ CoRE/Public/Cybershake"

--- a/dropbox_rclone/dropbox_rclone/contants.py
+++ b/dropbox_rclone/dropbox_rclone/contants.py
@@ -1,2 +1,2 @@
 # Dropbox directory
-CYBERSHAKE_DIRECTORY = "dropbox:/Quake\ CoRE/Public/Cybershake"
+CYBERSHAKE_DIRECTORY = "dropbox:/QuakeCoRE/Public/Cybershake"

--- a/dropbox_rclone/dropbox_rclone/scripts/cs_dropbox_download.py
+++ b/dropbox_rclone/dropbox_rclone/scripts/cs_dropbox_download.py
@@ -7,8 +7,6 @@ import tarfile
 
 from dropbox_rclone import contants as const
 
-# rclone ls dropbox:/Quake\ CoRE/Public/Cybershake/v22p12|grep -e "Source\|IM"| sed -E 's/^[[:space:]]+//' |cut -d" " -f2 |xargs -I {} rclone copy dropbox:/Quake\ CoRE/Cybershake/v22p12/{} . --progress
-
 DATA_TYPES = ["Source", "IM", "BB"]
 
 TAR_ERROR_LOG = "tar_error.log"

--- a/dropbox_rclone/dropbox_rclone/scripts/cs_dropbox_download.py
+++ b/dropbox_rclone/dropbox_rclone/scripts/cs_dropbox_download.py
@@ -5,8 +5,9 @@ import os
 
 import tarfile
 
+from dropbox_rclone import contants as const
 
-# rclone ls dropbox:Cybershake/v22p12|grep -e "Source\|IM"| sed -E 's/^[[:space:]]+//' |cut -d" " -f2 |xargs -I {} rclone copy dropbox:Cybershake/v22p12/{} . --progress
+# rclone ls dropbox:/Quake\ CoRE/Public/Cybershake/v22p12|grep -e "Source\|IM"| sed -E 's/^[[:space:]]+//' |cut -d" " -f2 |xargs -I {} rclone copy dropbox:/Quake\ CoRE/Cybershake/v22p12/{} . --progress
 
 DATA_TYPES = ["Source", "IM", "BB"]
 
@@ -109,7 +110,7 @@ def download(
     if exc_fault is None:
         exc_fault = []
 
-    dropbox_path = f"dropbox:Cybershake/{dropbox_cs_ver}"
+    dropbox_path = f"{const.CYBERSHAKE_DIRECTORY}/{dropbox_cs_ver}"
 
     p = subprocess.Popen(
         f"rclone lsd {dropbox_path}",
@@ -120,7 +121,6 @@ def download(
     out, err = p.communicate()
     out = out.decode("utf-8")
     err = err.decode("utf-8")
-
     assert "ERROR" not in err, f"CS version not found: {dropbox_cs_ver}"
 
     fault_names = [x.split(" ")[-1] for x in out.split("\n") if len(x) > 0]

--- a/dropbox_rclone/dropbox_rclone/scripts/cs_dropbox_upload.py
+++ b/dropbox_rclone/dropbox_rclone/scripts/cs_dropbox_upload.py
@@ -5,6 +5,7 @@ import subprocess
 import shutil
 import yaml
 
+from dropbox_rclone import contants as const
 
 FILE_PATTERN_CONF = "sync_patterns.yaml"
 OPTIONAL_PATTERN_MARKER = "$"
@@ -308,7 +309,7 @@ def upload(
     to_upload_dir = to_upload_root / fault_name
     tar_files_to_upload = [tf.name for tf in list(to_upload_dir.glob(tar_file))]
 
-    # rclone copy {src} dropbox:{dest}
+    # rclone copy {src} {dest}
     # 1. {src} is a file, and {dest} is a file, trivial
     # 2. {src} is a file, {dest} is a directory, the file will be placed under {dest}
     # 3. {src} is a directory, {dest} is a directory, all files under {src} will be copied to {dest}. No directory made
@@ -447,7 +448,7 @@ if __name__ == "__main__":
     to_pack_root.mkdir(exist_ok=True)
     to_upload_root.mkdir(exist_ok=True)
 
-    dropbox_path = f"dropbox:Cybershake/{cs_ver}"
+    dropbox_path = f"{const.CYBERSHAKE_DIRECTORY}/{cs_ver}"
 
     with open(files_to_sync, "r") as f:
         files_dict = yaml.safe_load(f)

--- a/dropbox_rclone/setup.py
+++ b/dropbox_rclone/setup.py
@@ -1,6 +1,7 @@
 """
 Install script for the cs_api package.
 """
+
 from setuptools import setup, find_packages
 
 setup(


### PR DESCRIPTION
Recent Dropbox Enterprise directory restructure enforced all data to belong to the personal folder instead of "QuakeCoRE" group. This prompted us to relocate most files to QuakeCoRE/Public folder, but `rclone` was accessing the personal folder by default.

```
(ringo310) seb56@c015kr:~/cs_dropbox_sync/dropbox_rclone/dropbox_rclone/scripts$ rclone lsd dropbox:
          -1 2024-08-08 10:36:04        -1 .Trash-1000
          -1 2024-08-08 10:36:04        -1 ENEQ621_2024
          -1 2024-08-08 10:36:04        -1 Portal Code
          -1 2024-08-08 10:36:04        -1 SWTeam
```

It was discovered that "/QuakeCoRE" still allows rclone to access the group folder

```
(ringo310) seb56@c015kr:~/cs_dropbox_sync/dropbox_rclone/dropbox_rclone/scripts$ rclone lsd dropbox:/QuakeCoRE/Public/Cybershake
          -1 2024-08-08 10:40:08        -1 _v18p6
          -1 2024-08-08 10:40:08        -1 _v22p6
          -1 2024-08-08 10:40:08        -1 v19p5
          -1 2024-08-08 10:40:08        -1 v20p4
          -1 2024-08-08 10:40:08        -1 v20p5
...

```
Hence this PR.